### PR TITLE
解决Win7下MclistView内嵌Edit后，使用搜狗输入法输入汉字变成2个汉字的问题。

### DIFF
--- a/SOUI/include/control/SMCListView.h
+++ b/SOUI/include/control/SMCListView.h
@@ -115,6 +115,8 @@ namespace SOUI
         void OnSize(UINT nType, CSize size);
         void OnDestroy();
 
+		LRESULT OnIMEChar(UINT uMsg, WPARAM wParam, LPARAM lParam);
+
         LRESULT OnMouseEvent(UINT uMsg,WPARAM wParam,LPARAM lParam);
 
         LRESULT OnKeyEvent( UINT uMsg,WPARAM wParam,LPARAM lParam );
@@ -137,6 +139,7 @@ namespace SOUI
             MSG_WM_SETFOCUS_EX(OnSetFocus)
             MSG_WM_KILLFOCUS_EX(OnKillFocus)
 			MSG_WM_SHOWWINDOW(OnShowWindow)
+			MESSAGE_HANDLER_EX(WM_IME_CHAR, OnIMEChar)
             MESSAGE_RANGE_HANDLER_EX(WM_MOUSEFIRST,WM_MOUSELAST,OnMouseEvent)
             MESSAGE_RANGE_HANDLER_EX(WM_KEYFIRST,WM_KEYLAST,OnKeyEvent)
             MESSAGE_RANGE_HANDLER_EX(WM_IME_STARTCOMPOSITION,WM_IME_KEYLAST,OnKeyEvent)

--- a/SOUI/src/control/SMCListView.cpp
+++ b/SOUI/src/control/SMCListView.cpp
@@ -785,6 +785,11 @@ SItemPanel * SMCListView::HitTest(CPoint & pt)
     return NULL;
 }
 
+LRESULT SMcListViewEx::OnIMEChar(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	return 0;
+}
+
 LRESULT SMCListView::OnMouseEvent(UINT uMsg,WPARAM wParam,LPARAM lParam)
 {
     SetMsgHandled(FALSE);


### PR DESCRIPTION
我在本地扩展McListview后，去掉WM_IME_CHAR消息后。经过QA测试后，搜狗，百度输入法在Win7，XP下输入一个字变两个字问题得以解决。