### PR TITLE
修复树控件bug

### DIFF
--- a/SOUI/include/control/STreeCtrl.h
+++ b/SOUI/include/control/STreeCtrl.h
@@ -133,7 +133,7 @@ protected:
 
     void SetChildrenState(HSTREEITEM hItem, int nCheckValue);
     BOOL CheckChildrenState(HSTREEITEM hItem, BOOL bCheck);    
-    void CheckState(HSTREEITEM hItem, BOOL bCheck, BOOL bCheckChild = TRUE);    
+    void CheckState(HSTREEITEM hItem);
 
     virtual void ItemLayout();
     virtual void CalcItemContentWidth(LPTVITEM pItem);


### PR DESCRIPTION
删除子节点后，父节点的checkbox状态不一致