### PR TITLE
修正 SRichEdit SetSel 当文本长超过 32768 后不能正确定位的Bug

### DIFF
--- a/SOUI/include/control/SRichEdit.h
+++ b/SOUI/include/control/SRichEdit.h
@@ -672,7 +672,7 @@ namespace SOUI
         *
         * Describe   设置选中
         */
-        void SetSel(DWORD dwSelection, BOOL bNoScroll = FALSE);
+        void SetSel(long nStartChar, long nEndChar, BOOL bNoScroll = FALSE);
         /**
         * SRichEdit::ReplaceSel
         * @brief     替换选中项

--- a/SOUI/include/control/SRichEdit.h
+++ b/SOUI/include/control/SRichEdit.h
@@ -672,7 +672,18 @@ namespace SOUI
         *
         * Describe   设置选中
         */
-        void SetSel(long nStartChar, long nEndChar, BOOL bNoScroll = FALSE);
+		void SetSel(DWORD dwSelection, BOOL bNoScroll = FALSE);
+
+		/**
+		* SRichEdit::SetSel
+		* @brief     设置选中
+		* @param     long nStartChar --
+		* @param     long nEndChar --
+		* @param     BOOL bNoScroll --
+		*
+		* Describe   设置选中, 支持超长文本
+		*/
+    	void SetSel(long nStartChar, long nEndChar, BOOL bNoScroll = FALSE);
         /**
         * SRichEdit::ReplaceSel
         * @brief     替换选中项

--- a/SOUI/src/control/SRichEdit.cpp
+++ b/SOUI/src/control/SRichEdit.cpp
@@ -1331,6 +1331,13 @@ void SRichEdit::ReplaceSel(LPCWSTR pszText,BOOL bCanUndo)
     SSendMessage(EM_REPLACESEL,(WPARAM)bCanUndo,(LPARAM)pszText);
 }
 
+void SRichEdit::SetSel(DWORD dwSelection, BOOL bNoScroll)
+{
+	SSendMessage(EM_SETSEL, LOWORD(dwSelection), HIWORD(dwSelection));
+	if (!bNoScroll)
+		SSendMessage(EM_SCROLLCARET, 0, 0L);
+}
+	
 void SRichEdit::SetSel(long nStartChar, long nEndChar, BOOL bNoScroll)
 {
     SSendMessage(EM_SETSEL, nStartChar, nEndChar);

--- a/SOUI/src/control/SRichEdit.cpp
+++ b/SOUI/src/control/SRichEdit.cpp
@@ -1331,9 +1331,9 @@ void SRichEdit::ReplaceSel(LPCWSTR pszText,BOOL bCanUndo)
     SSendMessage(EM_REPLACESEL,(WPARAM)bCanUndo,(LPARAM)pszText);
 }
 
-void SRichEdit::SetSel(DWORD dwSelection, BOOL bNoScroll)
+void SRichEdit::SetSel(long nStartChar, long nEndChar, BOOL bNoScroll)
 {
-    SSendMessage(EM_SETSEL, LOWORD(dwSelection), HIWORD(dwSelection));
+    SSendMessage(EM_SETSEL, nStartChar, nEndChar);
     if(!bNoScroll)
         SSendMessage(EM_SCROLLCARET, 0, 0L);
 }


### PR DESCRIPTION
原有接口位置只用了WORD来表示, 导致文本长度超过32768 后不能正确定位