### PR TITLE
修复树控件的勾选框bug

### DIFF
--- a/SOUI/src/control/STreeCtrl.cpp
+++ b/SOUI/src/control/STreeCtrl.cpp
@@ -434,11 +434,16 @@ HSTREEITEM STreeCtrl::InsertItem(LPTVITEM pItemObj,HSTREEITEM hParent,HSTREEITEM
 
     pItemObj->nLevel = GetItemLevel(hParent)+1;
 
+	BOOL bCheckState = FALSE;
+
     if(hParent!=STVI_ROOT)
     {        
         LPTVITEM pParentItem= GetItem(hParent);
         if(pParentItem->bCollapsed || !pParentItem->bVisible) 
             pItemObj->bVisible=FALSE;
+
+		if(pParentItem->nCheckBoxValue != pItemObj->nCheckBoxValue)
+			bCheckState = TRUE;
 
         if (!GetChildItem(hParent) && !pParentItem->bHasChildren)
         {
@@ -465,6 +470,7 @@ HSTREEITEM STreeCtrl::InsertItem(LPTVITEM pItemObj,HSTREEITEM hParent,HSTREEITEM
         Invalidate();
     }
 
+	if(bCheckState) CheckState(hParent);
     if(bEnsureVisible) EnsureVisible(hRet);
     return hRet;
 }


### PR DESCRIPTION
树控件新插入节点时，如果新节点和其父节点的勾选状态不一致时，父节点需要重新计算状态